### PR TITLE
Import of Streamlit libraries updated

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,11 +1,11 @@
 import sys
-from streamlit import cli as stcli
-import streamlit as st
+from streamlit.web import cli as stcli
+from streamlit import runtime
 from webapp import main
 
 
 if __name__ == "__main__":
-    if st._is_running_with_streamlit:
+    if runtime.exists():
         main()
     else:
         sys.argv = ["streamlit", "run", sys.argv[0]]


### PR DESCRIPTION
I've changed the library import for Streamlit to fix these two errors I got when I exected run.py with the current version of Streamlit installed:

- ImportError: cannot import name ‘cli’ from ‘streamlit’ 
- AttributeError: module 'streamlit' has no attribute '_is_running_with_streamlit'